### PR TITLE
updated dependency version of megaparsec

### DIFF
--- a/abnf.cabal
+++ b/abnf.cabal
@@ -39,7 +39,7 @@ library
   -- other-extensions:    
   build-depends:       base >=4.8 && <4.10,
                        text,
-                       megaparsec,
+                       megaparsec <6.0.0,
                        attoparsec,
                        containers
   hs-source-dirs:      src


### PR DESCRIPTION
megaparsec version >= 6.0.0 is no longer compatible