### PR TITLE
Support repeat number

### DIFF
--- a/src/Text/ABNF/ABNF/Parser.hs
+++ b/src/Text/ABNF/ABNF/Parser.hs
@@ -94,7 +94,7 @@ repetition = Repetition <$> repeat <*> element
 repeat :: Parser Repeat
 repeat = try asteriskNumbers <|> try singleNumber <|> pure (Repeat 1 (Just 1))
     where
-        singleNumber = Repeat 1 <$> (Just . read <$> some digitChar)
+        singleNumber = (\r -> Repeat r (Just r)) . read <$> some digitChar
         asteriskNumbers = do
             firstNumber <- option 0 (read <$> some digitChar)
             _ <- char '*'

--- a/test/ABNF.hs
+++ b/test/ABNF.hs
@@ -44,6 +44,8 @@ abnfTests = testGroup "ABNF Parser"
                 (Repetition (Repeat 1 (Just 2)) wsElement)
           , testCase "1-* times" $ testRep "1*%x20"
                 (Repetition (Repeat 1 Nothing) wsElement)
+          , testCase "7 times" $ testRep "7%x20"
+                (Repetition (Repeat 7 (Just 7)) wsElement)
           , testCase "* times" $ testRep "*%x20"
                 (Repetition (Repeat 0 Nothing) wsElement)
           ]


### PR DESCRIPTION
The ABNF format [allows for specific repetition](https://datatracker.ietf.org/doc/html/rfc5234#section-3.7) in the form `<n>element`, which is equivalent to `<n>*<n>element`.  However, `<n>element` was parsed into `Repeat 1 (Just n)`, equivalent to `1*<n>element` instead of `Repeat n (Just n)` as it should.  This PR fixes the issue (and adds a test for it).